### PR TITLE
Fixing MapTabbook/wxAuiNotebook/MapTab hierarchy.

### DIFF
--- a/source/editor_tabs.h
+++ b/source/editor_tabs.h
@@ -52,6 +52,8 @@ protected:
 	wxAuiNotebook* notebook;
 	std::map<wxWindow*, EditorTab*> conv;
 
+	friend class MapTab;
+
 	DECLARE_EVENT_TABLE();
 };
 

--- a/source/map_tab.cpp
+++ b/source/map_tab.cpp
@@ -27,7 +27,7 @@
 
 MapTab::MapTab(MapTabbook* aui, Editor* editor) :
 	EditorTab(),
-	MapWindow(aui, *editor),
+	MapWindow(aui->notebook, *editor),
 	aui(aui)
 {
 	iref = newd InternalReference;


### PR DESCRIPTION
The MapTab is currently being created as child of MapTabbook, the parent panel of the wxAuiNotebook, causing RME to crash while calling OpenGL drawing functions.

It only happens with wxWidgets 3.1.5. I don't know if it's because the new wxWidgets EGL implementation or something else, but this changes fixes the issue.

I'm not really sure if it was the best approach to make this change, but the classes are so entwined that it was hard to think about a better approach.