### PR TITLE
Ignoring control characters when rendering tooltips.

### DIFF
--- a/source/map_drawer.cpp
+++ b/source/map_drawer.cpp
@@ -1686,7 +1686,7 @@ void MapDrawer::DrawTooltips()
 					glutBitmapCharacter(GLUT_BITMAP_HELVETICA_18, '.');
 					if(char_count >= (MapTooltip::MAX_CHARS + 2))
 						break;
-				} else {
+				} else if (!iscntrl(*c)) {
 					glutBitmapCharacter(GLUT_BITMAP_HELVETICA_12, *c);
 				}
 			}


### PR DESCRIPTION
Fixing a issue mentioned by @Erza on pull request #323.