### PR TITLE
Fix spawntime overflowing when drawing

### DIFF
--- a/source/creature_brush.cpp
+++ b/source/creature_brush.cpp
@@ -18,6 +18,7 @@
 #include "main.h"
 
 #include "creature_brush.h"
+#include "gui.h"
 #include "settings.h"
 #include "tile.h"
 #include "creature.h"
@@ -79,15 +80,20 @@ void CreatureBrush::draw(BaseMap* map, Tile* tile, void* parameter)
 {
 	ASSERT(tile);
 	ASSERT(parameter);
-	if(canDraw(map, tile->getPosition())) {
+	draw_creature(map, tile);
+}
+
+void CreatureBrush::draw_creature(BaseMap* map, Tile* tile)
+{
+	if (canDraw(map, tile->getPosition())) {
 		undraw(map, tile);
-		if(creature_type) {
-			if(tile->spawn == nullptr && tile->getLocation()->getSpawnCount() == 0) {
+		if (creature_type) {
+			if (tile->spawn == nullptr && tile->getLocation()->getSpawnCount() == 0) {
 				// manually place spawn on location
 				tile->spawn = newd Spawn(1);
 			}
 			tile->creature = newd Creature(creature_type);
-			tile->creature->setSpawnTime(*(int*)parameter);
+			tile->creature->setSpawnTime(g_gui.GetSpawnTime());
 		}
 	}
 }

--- a/source/creature_brush.cpp
+++ b/source/creature_brush.cpp
@@ -87,8 +87,8 @@ void CreatureBrush::draw_creature(BaseMap* map, Tile* tile)
 {
 	if (canDraw(map, tile->getPosition())) {
 		undraw(map, tile);
-		if (creature_type) {
-			if (tile->spawn == nullptr && tile->getLocation()->getSpawnCount() == 0) {
+		if(creature_type) {
+			if(tile->spawn == nullptr && tile->getLocation()->getSpawnCount() == 0) {
 				// manually place spawn on location
 				tile->spawn = newd Spawn(1);
 			}

--- a/source/creature_brush.h
+++ b/source/creature_brush.h
@@ -34,6 +34,7 @@ public:
 
 	virtual bool canDraw(BaseMap* map, const Position& position) const;
 	virtual void draw(BaseMap* map, Tile* tile, void* parameter);
+	void draw_creature(BaseMap* map, Tile* tile);
 	virtual void undraw(BaseMap* map, Tile* tile);
 
 	CreatureType* getType() const {return creature_type;}

--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -1428,9 +1428,7 @@ void Editor::drawInternal(Position offset, bool alt, bool dodraw)
 			new_tile = map.allocator(map.createTileL(offset));
 		}
 		int param;
-		if(brush->isCreature()) {
-			param = g_gui.GetSpawnTime();
-		} else {
+		if(!brush->isCreature()) {
 			param = g_gui.GetBrushSize();
 		}
 		if(dodraw) {


### PR DESCRIPTION
This problem existed for a long time, I do not know how it happens but I suppose it is due to the memory control of the Tile pointer, although I do not know why.

Any questions or suggestions, you are free to tell me something, thank you very much.

**Before:** If you draw non-stop, after the first creature, all the others get a random time.
![GIF 29-07-2021 05-10-06 a  m](https://user-images.githubusercontent.com/28090948/127465349-c80f8020-393d-4470-b7a4-bbcf91c20797.gif)

**After:** Now draw non-stop, no problem with the spawntime ;)
![GIF 29-07-2021 05-09-03 a  m](https://user-images.githubusercontent.com/28090948/127465478-27528329-1072-4763-809f-8350409469aa.gif)
