### PR TITLE
Update walls.xml

### DIFF
--- a/data/1098/walls.xml
+++ b/data/1098/walls.xml
@@ -4,7 +4,6 @@
 			<item id="1050" chance="500"/>
 			<item id="1052" chance="0"/> <!-- This needs to be here for backwards compatibility -->
 			<item id="1058" chance="0"/> <!-- This needs to be here for backwards compatibility -->
-			<door id="6252" type="normal" open="false"/>
 			<door id="6253" type="normal" open="false"/>
 			<door id="6254" type="normal" open="true"/>
 			<door id="6257" type="locked" open="false"/>
@@ -21,7 +20,6 @@
 			<item id="1049" chance="400"/>
 			<item id="1054" chance="0"/> <!-- This needs to be here for backwards compatibility -->
 			<item id="1056" chance="0"/> <!-- This needs to be here for backwards compatibility -->
-			<door id="6249" type="normal" open="false"/>
 			<door id="6250" type="normal" open="false"/>
 			<door id="6251" type="normal" open="true"/>
 			<door id="6255" type="locked" open="false"/>
@@ -69,7 +67,6 @@
 			<item id="5153" chance="150"/>
 			<door id="1215" type="archway" open="false"/>
 			<door id="1216" type="archway" open="false"/>
-			<door id="1212" type="normal" open="false"/>
 			<door id="1213" type="normal" open="false"/>
 			<door id="1214" type="normal" open="true"/>
 			<door id="1221" type="locked" open="false"/>
@@ -91,7 +88,6 @@
 			<door id="1217" type="archway" open="false"/>
 			<door id="1218" type="archway" open="false"/>
 			<door id="1210" type="normal" open="false"/>
-			<door id="1209" type="normal" open="false"/>
 			<door id="1211" type="normal" open="true"/>
 			<door id="1219" type="locked" open="false"/>
 			<door id="1220" type="locked" open="true"/>
@@ -141,7 +137,6 @@
 			<item id="1034" chance="0"/>
 			<door id="1207" type="archway" open="false"/>
 			<door id="1208" type="archway" open="false"/>
-			<door id="5098" type="normal" open="false"/>
 			<door id="5099" type="normal" open="false"/>
 			<door id="5100" type="normal" open="true"/>
 			<door id="5101" type="locked" open="false"/>
@@ -160,7 +155,6 @@
 			<item id="1032" chance="0"/>
 			<door id="1205" type="archway" open="false"/>
 			<door id="1206" type="archway" open="false"/>
-			<door id="5107" type="normal" open="false"/>
 			<door id="5108" type="normal" open="false"/>
 			<door id="5109" type="normal" open="true"/>
 			<door id="5110" type="locked" open="false"/>
@@ -189,7 +183,6 @@
 			<item id="1061" chance="1"/>
 			<item id="1063" chance="0"/>
 			<item id="1069" chance="0"/>
-			<door id="1234" type="normal" open="false"/>
 			<door id="1235" type="normal" open="false"/>
 			<door id="1236" type="normal" open="true"/>
 			<door id="1239" type="locked" open="false"/>
@@ -206,7 +199,6 @@
 			<item id="1060" chance="1"/>
 			<item id="1065" chance="0"/>
 			<item id="1067" chance="0"/>
-			<door id="1231" type="normal" open="false"/>
 			<door id="1232" type="normal" open="false"/>
 			<door id="1233" type="normal" open="true"/>
 			<door id="1237" type="locked" open="false"/>
@@ -287,7 +279,6 @@
 			<item id="3421" chance="0"/>
 			<item id="3422" chance="0"/>
 
-			<door id="5116" type="normal" open="false"/>
 			<door id="5117" type="normal" open="false"/>
 			<door id="5118" type="normal" open="true"/>
 			<door id="5119" type="locked" open="false"/>
@@ -328,7 +319,6 @@
 			<item id="3412" chance="0"/>
 			<item id="3413" chance="0"/>
 
-			<door id="5125" type="normal" open="false"/>
 			<door id="5126" type="normal" open="false"/>
 			<door id="5127" type="normal" open="true"/>
 			<door id="5128" type="locked" open="false"/>
@@ -388,11 +378,10 @@
 			<item id="1114" chance="0"/>
 			<item id="1118" chance="0"/>
 
-			<door id="1252" type="normal" open="false"/>
 			<door id="1253" type="normal" open="false"/>
 			<door id="1254" type="normal" open="true"/>
-			<!--<door id="6200" type="locked" open="false"/>-->
-			<!--<door id="6201" type="locked" open="true"/>-->
+			<door id="5517" type="locked" open="false"/>
+			<door id="5518" type="locked" open="true"/>
 			<door id="1257" type="quest" open="false"/>
 			<door id="1258" type="quest" open="true"/>
 			<door id="1261" type="magic" open="false"/>
@@ -432,11 +421,10 @@
 			<item id="1116" chance="0"/>
 			<item id="5010" chance="0"/>
 
-			<door id="1249" type="normal" open="false"/>
 			<door id="1250" type="normal" open="false"/>
 			<door id="1251" type="normal" open="true"/>
-			<!--<door id="6198" type="locked" open="false"/>-->
-			<!--<door id="6199" type="locked" open="true"/>-->
+			<door id="5515" type="locked" open="false"/>
+			<door id="5516" type="locked" open="true"/>
 			<door id="1255" type="quest" open="false"/>
 			<door id="1256" type="quest" open="true"/>
 			<door id="1259" type="magic" open="false"/>
@@ -488,7 +476,6 @@
 			<item id="6848" chance="0"/> <!-- This needs to be here for backwards compatibility -->
 			<door id="6882" type="archway" open="false"/>
 			<door id="6884" type="archway" open="false"/>
-			<door id="6891" type="normal" open="false"/>
 			<door id="6892" type="normal" open="false"/>
 			<door id="6893" type="normal" open="true"/>
 			<door id="6894" type="locked" open="false"/>
@@ -508,7 +495,6 @@
 			<item id="6846" chance="0"/> <!-- This needs to be here for backwards compatibility -->
 			<door id="6883" type="archway" open="false"/>
 			<door id="6885" type="archway" open="false"/>
-			<door id="6900" type="normal" open="false"/>
 			<door id="6901" type="normal" open="false"/>
 			<door id="6902" type="normal" open="true"/>
 			<door id="6903" type="locked" open="false"/>
@@ -645,7 +631,6 @@
 			<item id="6148" chance="0"/>
 			<item id="6134" chance="0"/>
 			<item id="6146" chance="0"/>
-			<door id="6195" type="normal" open="false"/>
 			<door id="6196" type="normal" open="false"/>
 			<door id="6197" type="normal" open="true"/>
 			<door id="6200" type="locked" open="false"/>
@@ -664,7 +649,6 @@
 			<item id="6149" chance="0"/>
 			<item id="6151" chance="0"/>
 			<item id="6144" chance="0"/>
-			<door id="6192" type="normal" open="false"/>
 			<door id="6193" type="normal" open="false"/>
 			<door id="6194" type="normal" open="true"/>
 			<door id="6198" type="locked" open="false"/>
@@ -771,11 +755,10 @@
 			<item id="5262" chance="0"/> <!-- This needs to be here for backwards compatibility -->
 			<item id="5262" chance="0"/> <!-- This needs to be here for backwards compatibility -->
 			<item id="5264" chance="0"/> <!-- This needs to be here for backwards compatibility -->
-			<door id="5278" type="normal" open="false"/> --
-			<door id="5279" type="normal" open="false"/> --
-			<door id="5280" type="normal" open="true"/> --
-			<door id="5286" type="locked" open="false"/> --
-			<door id="5287" type="locked" open="true"/> --
+			<door id="5279" type="normal" open="false"/>
+			<door id="5280" type="normal" open="true"/>
+			<door id="5286" type="locked" open="false"/>
+			<door id="5287" type="locked" open="true"/>
 			<door id="5290" type="quest" open="false"/>
 			<door id="5291" type="quest" open="true"/>
 			<door id="5294" type="magic" open="false"/>
@@ -788,7 +771,6 @@
 			<item id="5268" chance="5"/>
 			<item id="5274" chance="1"/>
 			<item id="5275" chance="1"/>
-			<door id="5281" type="normal" open="false"/>
 			<door id="5282" type="normal" open="false"/>
 			<door id="5283" type="normal" open="true"/>
 			<door id="5284" type="locked" open="false"/>
@@ -826,7 +808,6 @@
 			<item id="8476" chance="1"/>
 			<item id="8478" chance="0"/>
 			<item id="8484" chance="0"/>
-			<door id="8544" type="normal" open="false"/>
 			<door id="8545" type="normal" open="false"/>
 			<door id="8546" type="normal" open="true"/>
 			<door id="8549" type="locked" open="false"/>
@@ -840,7 +821,6 @@
 			<item id="8475" chance="1"/>
 			<item id="8480" chance="0"/>
 			<item id="8482" chance="0"/>
-			<door id="8541" type="normal" open="false"/>
 			<door id="8542" type="normal" open="false"/>
 			<door id="8543" type="normal" open="true"/>
 			<door id="8547" type="locked" open="false"/>
@@ -925,7 +905,6 @@
 	<brush name="bamboo wall" type="wall" server_lookid="3424">
 		<wall type="horizontal">
 			<item id="3424" chance="1"/>
-			<door id="3535" type="normal" open="false"/>
 			<door id="3536" type="normal" open="false"/>
 			<door id="3537" type="normal" open="true"/>
 			<door id="3538" type="locked" open="false"/>
@@ -940,7 +919,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="3423" chance="1"/>
-			<door id="3544" type="normal" open="false"/>
 			<door id="3545" type="normal" open="false"/>
 			<door id="3546" type="normal" open="true"/>
 			<door id="3547" type="locked" open="false"/>
@@ -1017,7 +995,6 @@
 	<brush name="frozen wall" type="wall" server_lookid="6740">
 		<wall type="horizontal">
 			<item id="6740" chance="1"/>
-			<door id="7033" type="normal" open="false"/>
 			<door id="7034" type="normal" open="false"/>
 			<door id="7035" type="normal" open="true"/>
 			<door id="7036" type="locked" open="false"/>
@@ -1031,7 +1008,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="6739" chance="1"/>
-			<door id="7042" type="normal" open="false"/>
 			<door id="7043" type="normal" open="false"/>
 			<door id="7044" type="normal" open="true"/>
 			<door id="7045" type="locked" open="false"/>
@@ -1085,7 +1061,6 @@
 	<brush name="stone wall3" type="wall" server_lookid="9119">
 		<wall type="horizontal">
 			<item id="9119" chance="1"/>
-			<door id="9168" type="normal" open="false"/>
 			<door id="9169" type="normal" open="false"/>
 			<door id="9170" type="normal" open="true"/>
 			<door id="9173" type="locked" open="false"/>
@@ -1098,7 +1073,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="9118" chance="1"/>
-			<door id="9165" type="normal" open="false"/>
 			<door id="9166" type="normal" open="false"/>
 			<door id="9167" type="normal" open="true"/>
 			<door id="9171" type="locked" open="false"/>
@@ -1123,7 +1097,6 @@
 			<item id="9211" chance="5"/>
 			<item id="9212" chance="5"/>
 			<item id="9223" chance="2"/>
-			<door id="9270" type="normal" open="false"/>
 			<door id="9271" type="normal" open="false"/>
 			<door id="9272" type="normal" open="true"/>
 			<door id="9275" type="locked" open="false"/>
@@ -1138,7 +1111,6 @@
 			<item id="9208" chance="5"/>
 			<item id="9209" chance="5"/>
 			<item id="9222" chance="2"/>
-			<door id="9267" type="normal" open="false"/>
 			<door id="9268" type="normal" open="false"/>
 			<door id="9269" type="normal" open="true"/>
 			<door id="9273" type="locked" open="false"/>
@@ -1178,7 +1150,6 @@
 	<brush name="limestone wall" type="wall" server_lookid="10178">
 		<wall type="horizontal">
 			<item id="10178" chance="1"/>
-			<door id="10468" type="normal" open="false"/>
 			<door id="10469" type="normal" open="false"/>
 			<door id="10470" type="normal" open="true"/>
 			<door id="10471" type="locked" open="false"/>
@@ -1193,46 +1164,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="10177" chance="1"/>
-			<door id="10477" type="normal" open="false"/>
-			<door id="10478" type="normal" open="false"/>
-			<door id="10479" type="normal" open="true"/>
-			<door id="10480" type="locked" open="false"/>
-			<door id="10481" type="locked" open="true"/>
-			<door id="10482" type="quest" open="false"/>
-			<door id="10483" type="quest" open="true"/>
-			<door id="10484" type="magic" open="false"/>
-			<door id="10485" type="magic" open="true"/>
-			<door id="10489" type="hatch_window" open="false"/>
-			<door id="10491" type="hatch_window" open="true"/>
-			<door id="10487" type="window"/>
-		</wall>
-		<wall type="corner">
-			<item id="10181" chance="1"/>
-		</wall>
-		<wall type="pole">
-			<item id="10179" chance="1"/>
-		</wall>
-	</brush>
-
-	<brush name="limestone wall" type="wall" server_lookid="10178">
-		<wall type="horizontal">
-			<item id="10178" chance="1"/>
-			<door id="10468" type="normal" open="false"/>
-			<door id="10469" type="normal" open="false"/>
-			<door id="10470" type="normal" open="true"/>
-			<door id="10471" type="locked" open="false"/>
-			<door id="10472" type="locked" open="true"/>
-			<door id="10473" type="quest" open="false"/>
-			<door id="10474" type="quest" open="true"/>
-			<door id="10475" type="magic" open="false"/>
-			<door id="10476" type="magic" open="true"/>
-			<door id="10488" type="hatch_window" open="false"/>
-			<door id="10490" type="hatch_window" open="true"/>
-			<door id="10486" type="window"/>
-		</wall>
-		<wall type="vertical">
-			<item id="10177" chance="1"/>
-			<door id="10477" type="normal" open="false"/>
 			<door id="10478" type="normal" open="false"/>
 			<door id="10479" type="normal" open="true"/>
 			<door id="10480" type="locked" open="false"/>
@@ -1258,7 +1189,6 @@
 			<item id="10227" chance="10"/>
 			<item id="10245" chance="6"/>
 			<item id="10246" chance="2"/>
-			<door id="10271" type="normal" open="false"/>
 			<door id="10272" type="normal" open="false"/>
 			<door id="10273" type="normal" open="true"/>
 			<door id="10276" type="locked" open="false"/>
@@ -1275,7 +1205,6 @@
 			<item id="10226" chance="10"/>
 			<item id="10247" chance="6"/>
 			<item id="10248" chance="2"/>
-			<door id="10268" type="normal" open="false"/>
 			<door id="10269" type="normal" open="false"/>
 			<door id="10270" type="normal" open="true"/>
 			<door id="10274" type="locked" open="false"/>
@@ -1544,7 +1473,6 @@
 	<brush name="venore wall" type="wall" server_lookid="19410">
 		<wall type="horizontal">
 			<item id="19410" chance="1"/>
-			<door id="19840" type="normal" open="false"/>
 			<door id="19841" type="normal" open="false"/>
 			<door id="19842" type="normal" open="true"/>
 			<door id="19843" type="locked" open="false"/>
@@ -1559,7 +1487,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="19405" chance="1"/>
-			<door id="19849" type="normal" open="false"/>
 			<door id="19850" type="normal" open="false"/>
 			<door id="19851" type="normal" open="true"/>
 			<door id="19852" type="locked" open="false"/>
@@ -1583,7 +1510,6 @@
 	<brush name="venore brick wall" type="wall" server_lookid="19485">
 		<wall type="horizontal">
 			<item id="19485" chance="1"/>
-			<door id="19980" type="normal" open="false"/>
 			<door id="19981" type="normal" open="false"/>
 			<door id="19982" type="normal" open="true"/>
 			<door id="19983" type="locked" open="false"/>
@@ -1596,7 +1522,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="19481" chance="1"/>
-			<door id="19989" type="normal" open="false"/>
 			<door id="19990" type="normal" open="false"/>
 			<door id="19991" type="normal" open="true"/>
 			<door id="19992" type="locked" open="false"/>
@@ -1727,7 +1652,6 @@
 	<brush name="zaoan wall3" type="wall" server_lookid="10663">
 		<wall type="horizontal">
 			<item id="10663" chance="1"/>
-			<door id="10775" type="normal" open="false"/>
 			<door id="10776" type="normal" open="false"/>
 			<door id="10777" type="normal" open="true"/>
 			<door id="10780" type="quest" open="false"/>
@@ -1739,7 +1663,6 @@
 		</wall>
 		<wall type="vertical">
 			<item id="10661" chance="1"/>
-			<door id="10784" type="normal" open="false"/>
 			<door id="10785" type="normal" open="false"/>
 			<door id="10786" type="normal" open="true"/>
 			<door id="10789" type="quest" open="false"/>
@@ -1943,7 +1866,6 @@
 		<wall type="horizontal">
 			<item id="25201" chance="10"/>
 			<item id="25203" chance="10"/>
-			<door id="25283" type="normal" open="false"/>
 			<door id="25284" type="normal" open="false"/>
 			<door id="25285" type="normal" open="true"/>
 			<door id="25286" type="quest" open="false"/>
@@ -1952,7 +1874,6 @@
 		<wall type="vertical">
 			<item id="25200" chance="10"/>
 			<item id="25205" chance="10"/>
-			<door id="25290" type="normal" open="false"/>
 			<door id="25291" type="normal" open="false"/>
 			<door id="25292" type="normal" open="true"/>
 			<door id="25293" type="quest" open="false"/>


### PR DESCRIPTION
- fixed default normal doors being the locked version
- added missing padlock doors to white stone wall (id 1112)
- removed duplicated limestone wall brush (id 10178)

fixes #363

what I did was just remove an unnecessary door entry in each brush that had 3 "normal" doors, reasons:

1. one is a locked version that should not be opened at all and it was being the "default" door
2. there is no need and makes no sense to have 3 entries if only 2 are actually being used
3. to make it be synchronized with master tfs
4. it is backward compatible