### PR TITLE
Fix build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(rme)
 
@@ -6,7 +6,7 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-set(CMAKE_CXX_FLAGS                "-Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -std=c++0x -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result")
+set(CMAKE_CXX_FLAGS                "-Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result")
 set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g -D__DEBUG__")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
@@ -27,10 +27,14 @@ find_package(Boost 1.34.0 COMPONENTS thread system REQUIRED)
 find_package(wxWidgets COMPONENTS html aui gl adv core net base REQUIRED)
 
 find_package(GLUT REQUIRED)
+find_package(ZLIB REQUIRED)
 
 include(${wxWidgets_USE_FILE})
 include(source/CMakeLists.txt)
 add_executable(rme ${rme_H} ${rme_SRC})
 
-include_directories(${Boost_INCLUDE_DIRS} ${LibArchive_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR} ${GLUT_INCLUDE_DIRS})
-target_link_libraries(rme ${wxWidgets_LIBRARIES} ${Boost_LIBRARIES} ${LibArchive_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARY})
+set_target_properties(rme PROPERTIES CXX_STANDARD 17)
+set_target_properties(rme PROPERTIES CXX_STANDARD_REQUIRED ON)
+
+include_directories(${Boost_INCLUDE_DIRS} ${LibArchive_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR} ${GLUT_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
+target_link_libraries(rme ${wxWidgets_LIBRARIES} ${Boost_LIBRARIES} ${LibArchive_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/source/dat_debug_view.h
+++ b/source/dat_debug_view.h
@@ -20,7 +20,7 @@
 
 class DatDebugViewListBox;
 
-class DatDebugView : wxPanel
+class DatDebugView : public wxPanel
 {
 public:
 	DatDebugView(wxWindow* parent);

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -139,7 +139,7 @@ wxString GUI::GetDataDirectory()
 	{
 		exec_directory = dynamic_cast<wxStandardPaths&>(wxStandardPaths::Get()).GetExecutablePath();
 	}
-	catch(std::bad_cast)
+	catch(const std::bad_cast&)
 	{
 		throw; // Crash application (this should never happend anyways...)
 	}
@@ -156,7 +156,7 @@ wxString GUI::GetExecDirectory()
 	{
 		exec_directory = dynamic_cast<wxStandardPaths&>(wxStandardPaths::Get()).GetExecutablePath();
 	}
-	catch(std::bad_cast)
+	catch(const std::bad_cast&)
 	{
 		wxLogError("Could not fetch executable directory.");
 	}
@@ -1183,7 +1183,7 @@ void GUI::DestroyLoadBar()
 
 void GUI::ShowWelcomeDialog(const wxBitmap &icon) {
     std::vector<wxString> recent_files = root->GetRecentFiles();
-    welcomeDialog = newd WelcomeDialog(__W_RME_APPLICATION_NAME__, "Version " + __W_RME_VERSION__, root->FromDIP(wxSize(800, 480)), icon, recent_files);
+    welcomeDialog = newd WelcomeDialog(__W_RME_APPLICATION_NAME__, "Version " + __W_RME_VERSION__, FROM_DIP(root, wxSize(800, 480)), icon, recent_files);
     welcomeDialog->Bind(wxEVT_CLOSE_WINDOW, &GUI::OnWelcomeDialogClosed, this);
     welcomeDialog->Bind(WELCOME_DIALOG_ACTION, &GUI::OnWelcomeDialogAction, this);
     welcomeDialog->Show();

--- a/source/main.h
+++ b/source/main.h
@@ -134,4 +134,10 @@ typedef wxFileName FileName;
 
 #include "rme_forward_declarations.h"
 
+#if wxCHECK_VERSION(3, 1, 0)
+        #define FROM_DIP(widget, size) widget->FromDIP(size)
+#else
+        #define FROM_DIP(widget, size) size
+#endif
+
 #endif

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -524,7 +524,7 @@ bool MainMenuBar::Load(const FileName& path, wxArrayString& warnings, wxString& 
 	entries[0].Set(wxACCEL_CTRL, (int)'Z', MAIN_FRAME_MENU + MenuBar::UNDO);
 	entries[1].Set(wxACCEL_CTRL | wxACCEL_SHIFT, (int)'Z', MAIN_FRAME_MENU + MenuBar::REDO);
 	entries[2].Set(wxACCEL_CTRL, (int)'F', MAIN_FRAME_MENU + MenuBar::FIND_ITEM);
-	entries[3].Set(wxACCEL_CTRL | wxACCEL_SHIFT, (int)'F', MAIN_FRAME_MENU + MenuBar::REPLACE_ITEM);
+	entries[3].Set(wxACCEL_CTRL | wxACCEL_SHIFT, (int)'F', MAIN_FRAME_MENU + MenuBar::REPLACE_ITEMS);
 	entries[4].Set(wxACCEL_NORMAL, (int)'A', MAIN_FRAME_MENU + MenuBar::AUTOMAGIC);
 	entries[5].Set(wxACCEL_CTRL, (int)'B', MAIN_FRAME_MENU + MenuBar::BORDERIZE_SELECTION);
 	entries[6].Set(wxACCEL_NORMAL, (int)'P', MAIN_FRAME_MENU + MenuBar::GOTO_PREVIOUS_POSITION);

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -151,7 +151,7 @@ namespace MenuBar
 
 class MainFrame;
 
-class MainMenuBar : wxEvtHandler
+class MainMenuBar : public wxEvtHandler
 {
 public:
 	MainMenuBar(MainFrame* frame);

--- a/source/main_toolbar.cpp
+++ b/source/main_toolbar.cpp
@@ -43,7 +43,7 @@ inline wxBitmap* _wxGetBitmapFromMemory(const unsigned char* data, int length)
 
 MainToolBar::MainToolBar(wxWindow* parent, wxAuiManager* manager)
 {
-	wxSize icon_size = parent->FromDIP(wxSize(16, 16));
+	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 	wxBitmap new_bitmap = wxArtProvider::GetBitmap(wxART_NEW, wxART_TOOLBAR, icon_size);
 	wxBitmap open_bitmap = wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_TOOLBAR, icon_size);
 	wxBitmap save_bitmap = wxArtProvider::GetBitmap(wxART_FILE_SAVE, wxART_TOOLBAR, icon_size);
@@ -104,13 +104,13 @@ MainToolBar::MainToolBar(wxWindow* parent, wxAuiManager* manager)
 
 	position_toolbar = newd wxAuiToolBar(parent, TOOLBAR_POSITION, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORZ_TEXT);
 	position_toolbar->SetToolBitmapSize(icon_size);
-	x_control = newd NumberTextCtrl(position_toolbar, wxID_ANY, 0, 0, MAP_MAX_WIDTH, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, parent->FromDIP(wxSize(60, 20)));
+	x_control = newd NumberTextCtrl(position_toolbar, wxID_ANY, 0, 0, MAP_MAX_WIDTH, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
 	x_control->SetToolTip("X Coordinate");
-	y_control = newd NumberTextCtrl(position_toolbar, wxID_ANY, 0, 0, MAP_MAX_HEIGHT, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, parent->FromDIP(wxSize(60, 20)));
+	y_control = newd NumberTextCtrl(position_toolbar, wxID_ANY, 0, 0, MAP_MAX_HEIGHT, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
 	y_control->SetToolTip("Y Coordinate");
-	z_control = newd NumberTextCtrl(position_toolbar, wxID_ANY, 0, 0, MAP_MAX_LAYER, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, parent->FromDIP(wxSize(35, 20)));
+	z_control = newd NumberTextCtrl(position_toolbar, wxID_ANY, 0, 0, MAP_MAX_LAYER, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, FROM_DIP(parent, wxSize(35, 20)));
 	z_control->SetToolTip("Z Coordinate");
-	go_button = newd wxButton(position_toolbar, TOOLBAR_POSITION_GO, wxEmptyString, wxDefaultPosition, parent->FromDIP(wxSize(22, 20)));
+	go_button = newd wxButton(position_toolbar, TOOLBAR_POSITION_GO, wxEmptyString, wxDefaultPosition, FROM_DIP(parent, wxSize(22, 20)));
 	go_button->SetBitmap(go_bitmap);
 	go_button->SetToolTip("Go To Position");
 	position_toolbar->AddControl(x_control);

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -515,7 +515,7 @@ wxNotebookPage* PreferencesWindow::CreateClientPage()
 	topsizer->AddSpacer(10);
 
 	wxScrolledWindow *client_list_window = newd wxScrolledWindow(client_page, wxID_ANY, wxDefaultPosition, wxDefaultSize);
-	client_list_window->SetMinSize(FromDIP(wxSize(450, 450)));
+	client_list_window->SetMinSize(FROM_DIP(this, wxSize(450, 450)));
     auto * client_list_sizer = newd wxFlexGridSizer(2, 10, 10);
 	client_list_sizer->AddGrowableCol(1);
 

--- a/source/welcome_dialog.cpp
+++ b/source/welcome_dialog.cpp
@@ -35,7 +35,7 @@ WelcomeDialog::WelcomeDialog(const wxString& title_text,
                                                      title_text,
                                                      version_text,
                                                      base_colour,
-                                                     wxBitmap(rme_logo.ConvertToImage().Scale(FromDIP(48), FromDIP(48))),
+                                                     wxBitmap(rme_logo.ConvertToImage().Scale(FROM_DIP(this, 48), FROM_DIP(this, 48))),
                                                      recent_files);
 }
 
@@ -104,7 +104,7 @@ WelcomeDialogPanel::WelcomeDialogPanel(WelcomeDialog *dialog,
     recent_maps_panel->SetMaxSize(wxSize(size.x / 2, size.y));
     recent_maps_panel->SetBackgroundColour(base_colour.ChangeLightness(98));
 
-    wxSize button_size = FromDIP(wxSize(150, 35));
+    wxSize button_size = FROM_DIP(this, wxSize(150, 35));
     wxColour button_base_colour = base_colour.ChangeLightness(90);
 
     int button_pos_center_x = size.x / 4 - button_size.x / 2;
@@ -139,9 +139,9 @@ WelcomeDialogPanel::WelcomeDialogPanel(WelcomeDialog *dialog,
     wxSizer *rootSizer = newd wxBoxSizer(wxHORIZONTAL);
     wxSizer *buttons_sizer = newd wxBoxSizer(wxVERTICAL);
     buttons_sizer->AddSpacer(size.y / 2);
-    buttons_sizer->Add(new_map_button, 0, wxALIGN_CENTER | wxTOP, FromDIP(10));
-    buttons_sizer->Add(open_map_button, 0, wxALIGN_CENTER | wxTOP, FromDIP(10));
-    buttons_sizer->Add(preferences_button, 0, wxALIGN_CENTER | wxTOP, FromDIP(10));
+    buttons_sizer->Add(new_map_button, 0, wxALIGN_CENTER | wxTOP, FROM_DIP(this, 10));
+    buttons_sizer->Add(open_map_button, 0, wxALIGN_CENTER | wxTOP, FROM_DIP(this, 10));
+    buttons_sizer->Add(preferences_button, 0, wxALIGN_CENTER | wxTOP, FROM_DIP(this, 10));
 
     wxSizer *vertical_sizer = newd wxBoxSizer(wxVERTICAL);
     wxSizer *horizontal_sizer = newd wxBoxSizer(wxHORIZONTAL);
@@ -150,7 +150,7 @@ WelcomeDialogPanel::WelcomeDialogPanel(WelcomeDialog *dialog,
     m_show_welcome_dialog_checkbox->SetValue(g_settings.getInteger(Config::WELCOME_DIALOG) == 1);
     m_show_welcome_dialog_checkbox->Bind(wxEVT_CHECKBOX, &WelcomeDialog::OnCheckboxClicked, dialog);
     m_show_welcome_dialog_checkbox->SetBackgroundColour(m_background_colour);
-    horizontal_sizer->Add(m_show_welcome_dialog_checkbox, 0, wxALIGN_BOTTOM | wxALL, FromDIP(10));
+    horizontal_sizer->Add(m_show_welcome_dialog_checkbox, 0, wxALIGN_BOTTOM | wxALL, FROM_DIP(this, 10));
     vertical_sizer->Add(buttons_sizer, 1, wxEXPAND);
     vertical_sizer->Add(horizontal_sizer, 1, wxEXPAND);
 
@@ -170,7 +170,7 @@ void WelcomeDialogPanel::OnPaint(const wxPaintEvent &event) {
     dc.SetPen(wxPen(m_background_colour));
     dc.DrawRectangle(wxRect(wxPoint(0, 0), GetClientSize()));
 
-    dc.DrawBitmap(m_rme_logo, wxPoint(GetSize().x / 4 - m_rme_logo.GetWidth() / 2, FromDIP(40)), true);
+    dc.DrawBitmap(m_rme_logo, wxPoint(GetSize().x / 4 - m_rme_logo.GetWidth() / 2, FROM_DIP(this, 40)), true);
 
     wxFont font = GetFont();
     font.SetPointSize(18);
@@ -260,8 +260,8 @@ RecentItem::RecentItem(wxWindow *parent,
     wxBoxSizer *mainSizer = newd wxBoxSizer(wxHORIZONTAL);
     wxBoxSizer *sizer = newd wxBoxSizer(wxVERTICAL);
     sizer->Add(m_title);
-    sizer->Add(m_file_path, 1, wxTOP, FromDIP(2));
-    mainSizer->Add(sizer, 0, wxEXPAND | wxALL, FromDIP(8));
+    sizer->Add(m_file_path, 1, wxTOP, FROM_DIP(this, 2));
+    mainSizer->Add(sizer, 0, wxEXPAND | wxALL, FROM_DIP(this, 8));
     Bind(wxEVT_ENTER_WINDOW, &RecentItem::OnMouseEnter, this);
     Bind(wxEVT_LEAVE_WINDOW, &RecentItem::OnMouseLeave, this);
     m_title->Bind(wxEVT_LEFT_UP, &RecentItem::PropagateItemClicked, this);


### PR DESCRIPTION
- Updated the minimum required CMake version.
- Updated the minimum required C++ standard version to match the
  functions used in the code base.
- Added missing `public` visibility specifier for classes deriving from
  wxEvtHandler (DatDebugView and MainMenuBar) that is required to
  access the event table from the derived classes.
- Fixed a typo in the MainMenuBar code (`REPLACE_ITEM` =>
  `REPLACE_ITEMS`).
- Added missing ZLIB search to the CMake project (previously it was
  implicitly linked by older wxWidgets versions?).
- Fixed GLUT compatibility with newer CMake version.
- Added a new `FROM_DIP` macro that fixes wxSize scaling compatibility
  with wxWidgets <3.1.0.
- Fixed catching std::bad_cast exceptions by value instead of const
  ref.

Closes #329.
Closes #345.
Closes #371.
Closes #373.
Closes #375.