### PR TITLE
Avoid loadSpriteMetadata from trying to load invalid .dat 

### DIFF
--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -401,6 +401,11 @@ bool GraphicManager::loadSpriteMetadata(const FileName& datafile, wxString& erro
 
 	dat_format = client_version->getDatFormatForSignature(datSignature);
 
+	if(dat_format == DAT_FORMAT_UNKNOWN) {
+		error += "Failed to open " + datafile.GetFullPath() + " for reading\nCould not locate datSignature (0x" << wxString::Format(wxT("%02x"), datSignature) << ") compatible with client version " << client_version->getName();
+		return false;
+	}
+
 	if(!otfi_found) {
 		is_extended = dat_format >= DAT_FORMAT_96;
 		has_frame_durations = dat_format >= DAT_FORMAT_1050;


### PR DESCRIPTION
On GraphicManager::loadSpriteMetadata there is a lack of failure checkage after trying to getDatFormatForSignature, which may return as DAT_FORMAT_UNKNOWN. When it is the case, the method should not continue running and return an error.
Without this modification, the program may get stuck. It affects too the local flags:  is_extended,  has_frame_durations and has_frame_groups