### PR TITLE
fix crash on invalid friend for wallbrush

### DIFF
--- a/source/wall_brush.cpp
+++ b/source/wall_brush.cpp
@@ -229,6 +229,7 @@ bool WallBrush::load(pugi::xml_node node, wxArrayString& warnings)
 					friends.push_back(brush->getID());
 				} else {
 					warnings.push_back("Brush '" + wxstr(name) + "' is not defined.");
+					continue;
 				}
 
 				if(childNode.attribute("redirect").as_bool()) {


### PR DESCRIPTION
## steps to reproduce
- go to any wallbrush
- add `<friend name="foeupfaouaewuo" redirect="true"/>` (any brush name that is not in use)
- try to create/open a map on the edited version

## context
currently crash is happening because after the warning, the loop continues to this instruction:
`if (!brush->isWall()) {`

and `brush` is `nullptr` here