### PR TITLE
Replace items fix

### DIFF
--- a/source/replace_items_window.cpp
+++ b/source/replace_items_window.cpp
@@ -374,6 +374,8 @@ void ReplaceItemsDialog::OnExecuteButtonClicked(wxCommandEvent& WXUNUSED(event))
 
 	tab->Refresh();
 	close_button->Enable(true);
+	replace_button->Enable(true);
+	with_button->Enable(true);
 	UpdateWidgets();
 }
 


### PR DESCRIPTION
Everytime you replace items you have to close and open the window again to add more items, because the button is not enabled again after execution. This PR fixes that.