### PR TITLE
Fix depot crash

### DIFF
--- a/source/old_properties_window.cpp
+++ b/source/old_properties_window.cpp
@@ -469,8 +469,8 @@ void OldPropertiesWindow::OnFocusChange(wxFocusEvent& event)
 void OldPropertiesWindow::OnClickOK(wxCommandEvent& WXUNUSED(event))
 {
 	if(edit_item) {
-		int new_uid = unique_id_field->GetValue();
-		int new_aid = action_id_field->GetValue();
+		int new_uid = (unique_id_field ? unique_id_field->GetValue() : 0);
+		int new_aid = (action_id_field ? action_id_field->GetValue() : 0);
 		bool uid_changed = false;
 		bool aid_changed = false;
 


### PR DESCRIPTION
Issue:
Pressing ok in depot properties makes rme to crash.