### PR TITLE
improve: replacing boosts with std functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ data/user
 *.opendb
 *.filters
 *.user
+*.vs
 
 vcproj/ipch/
 vcproj/Beta Release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,23 +6,24 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-set(CMAKE_CXX_FLAGS                "-Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result")
-set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g -D__DEBUG__")
-set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+find_package(asio CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 find_package(OpenGL REQUIRED)
 
-if(APPLE)
-    set(CMAKE_PREFIX_PATH /usr/local/opt/libarchive)
-endif()
-find_package(LibArchive REQUIRED)
+# LibArchive disabled in compilation level by default, see "#define OTGZ_SUPPORT" in the "definitions.h" file
+# If you need use, enable this:
+#find_package(LibArchive REQUIRED)
+#${LibArchive_INCLUDE_DIRS} ${LibArchive_LIBRARIES}
+
+#if(APPLE)
+#    set(CMAKE_PREFIX_PATH /usr/local/opt/libarchive)
+#endif()
 
 if(WIN32)
     set(Boost_THREADAPI win32)
 endif()
-find_package(Boost 1.34.0 COMPONENTS thread system REQUIRED)
 
 find_package(wxWidgets COMPONENTS html aui gl adv core net base REQUIRED)
 
@@ -31,10 +32,25 @@ find_package(ZLIB REQUIRED)
 
 include(${wxWidgets_USE_FILE})
 include(source/CMakeLists.txt)
-add_executable(rme ${rme_H} ${rme_SRC})
+add_executable(${PROJECT_NAME} ${rme_H} ${rme_SRC})
 
-set_target_properties(rme PROPERTIES CXX_STANDARD 17)
-set_target_properties(rme PROPERTIES CXX_STANDARD_REQUIRED ON)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON)
 
-include_directories(${Boost_INCLUDE_DIRS} ${LibArchive_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR} ${GLUT_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
-target_link_libraries(rme ${wxWidgets_LIBRARIES} ${Boost_LIBRARIES} ${LibArchive_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES} ${ZLIB_LIBRARIES})
+include_directories(
+    ${LibArchive_INCLUDE_DIRS}
+    ${OPENGL_INCLUDE_DIR}
+    ${GLUT_INCLUDE_DIRS}
+    ${ZLIB_INCLUDE_DIR}
+
+    )
+target_link_libraries(${PROJECT_NAME}
+    ${wxWidgets_LIBRARIES}
+    ${LibArchive_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    ${GLUT_LIBRARIES}
+    ${ZLIB_LIBRARIES}
+    fmt::fmt
+    asio::asio
+    nlohmann_json::nlohmann_json
+)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/source/about_window.cpp
+++ b/source/about_window.cpp
@@ -169,6 +169,17 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 {
 	wxString about;
 
+	std::string compiler;
+#if defined(__clang__)
+	compiler = fmt::format("Clang++ {}.{}.{}", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(_MSC_VER)
+	compiler = fmt::format("Microsoft Visual Studio {}", _MSC_VER);
+#elif defined(__GNUC__)
+	compiler = fmt::format("G++ {}.{}.{}", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#else
+	compiler = "unknown";
+#endif
+
 	about << "This is an OpenTibia Map Editor created by Remere.\n";
 	about << "Version " << __W_RME_VERSION__ << " for ";
 	about <<
@@ -192,7 +203,7 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 	about << "under certain conditions.\n";
 	about << "\n";
 	about << "Compiled on: " << __TDATE__ << " : " << __TTIME__ << "\n";
-	about << "Compiled with: " << BOOST_COMPILER << "\n";
+	about << "Compiled with: " << compiler << "\n";
 
 	topsizer = newd wxBoxSizer(wxVERTICAL);
 

--- a/source/action.cpp
+++ b/source/action.cpp
@@ -466,7 +466,7 @@ void BatchAction::commit()
 
 void BatchAction::undo()
 {
-	for(Action* action : boost::adaptors::reverse(batch)) {
+	for(Action* action : std::views::reverse(batch)) {
 		action->undo(nullptr);
 	}
 }

--- a/source/application.cpp
+++ b/source/application.cpp
@@ -639,3 +639,14 @@ void MainFrame::PrepareDC(wxDC& dc)
 	dc.SetUserScale( 1.0, 1.0 );
 	dc.SetMapMode( wxMM_TEXT );
 }
+
+// This is necessary for cmake to understand that it needs to set the executable
+int main(int argc, char** argv)
+{
+	wxEntryStart(argc, argv); // Start the wxWidgets library
+	Application* app = new Application(); // Create the application object
+	wxApp::SetInstance(app); // Informs wxWidgets that app is the application object
+	wxEntry(); // Call the wxEntry() function to start the application execution
+	wxEntryCleanup(); // Clear the wxWidgets library
+	return 0;
+}

--- a/source/client_version.h
+++ b/source/client_version.h
@@ -192,11 +192,15 @@ struct ClientData
 class ClientVersion;
 typedef std::vector<ClientVersion*> ClientVersionList;
 
-class ClientVersion : boost::noncopyable
+class ClientVersion
 {
 public:
 	ClientVersion(OtbVersion otb, std::string versionName, wxString path);
 	~ClientVersion() = default;
+
+	// Ensures we don't accidentally copy it.
+	ClientVersion(const ClientVersion &) = delete;
+	ClientVersion &operator=(const ClientVersion &) = delete;
 
 	static void loadVersions();
 	static void unloadVersions();

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -116,6 +116,16 @@ void replaceString(std::string& str, const std::string sought, const std::string
 	}
 }
 
+void trim(std::string& str) {
+	// Trim from start
+	str.erase(str.begin(), std::find_if(str.begin(), str.end(),
+		[](int ch) { return !std::isspace(ch); }));
+
+	// Trim from end
+	str.erase(std::find_if(str.rbegin(), str.rend(),
+		[](int ch) { return !std::isspace(ch); }).base(), str.end());
+}
+
 void trim_right(std::string& source, const std::string& t)
 {
 	source.erase(source.find_last_not_of(t)+1);

--- a/source/common.h
+++ b/source/common.h
@@ -47,6 +47,7 @@ double ws2f(wxString s);
 
 // replaces all instances of sought in str with replacement
 void replaceString(std::string& str, const std::string sought, const std::string replacement);
+void trim(std::string& str);
 // Removes all characters in t from source (from either start or beginning of the string)
 void trim_right(std::string& source, const std::string& t);
 void trim_left(std::string& source, const std::string& t);

--- a/source/definitions.h
+++ b/source/definitions.h
@@ -50,7 +50,7 @@
 #endif
 // OS
 
-#define OTGZ_SUPPORT 1
+#define OTGZ_SUPPORT 0
 #define ASSETS_NAME "Tibia"
 
 #ifdef __VISUALC__

--- a/source/doodad_brush.cpp
+++ b/source/doodad_brush.cpp
@@ -20,8 +20,6 @@
 #include "doodad_brush.h"
 #include "basemap.h"
 
-#include <boost/lexical_cast.hpp>
-
 //=============================================================================
 // Doodad brush
 
@@ -216,8 +214,20 @@ bool DoodadBrush::load(pugi::xml_node node, wxArrayString& warnings)
 	if(!thicknessString.empty()) {
 		size_t slash = thicknessString.find('/');
 		if(slash != std::string::npos) {
-			thickness = boost::lexical_cast<int32_t>(thicknessString.substr(0, slash));
-			thickness_ceiling = std::max<int32_t>(thickness, boost::lexical_cast<int32_t>(thicknessString.substr(slash + 1)));
+			try {
+				thickness = std::stoi(thicknessString.substr(0, slash));
+			} catch (const std::invalid_argument&) {
+				thickness = 0;
+			} catch (const std::out_of_range&) {
+				thickness = 0;
+			}
+			try {
+				thickness_ceiling = std::stoi(thicknessString.substr(slash + 1));
+			} catch (const std::invalid_argument&) {
+				thickness_ceiling = 0;
+			} catch (const std::out_of_range&) {
+				thickness_ceiling = 0;
+			}
 		}
 	}
 

--- a/source/filehandle.h
+++ b/source/filehandle.h
@@ -50,11 +50,15 @@ enum NodeType {
 	ESCAPE_CHAR = 0xfd,
 };
 
-class FileHandle : boost::noncopyable
+class FileHandle
 {
 public:
 	FileHandle() : error_code(FILE_NO_ERROR), file(nullptr) {}
 	virtual ~FileHandle() { close(); }
+
+	// Ensures we don't accidentally copy it.
+	FileHandle(const FileHandle &) = delete;
+	FileHandle &operator=(const FileHandle &) = delete;
 
 	virtual void close();
 	virtual bool isOpen() { return file != nullptr; }

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -407,7 +407,7 @@ bool Container::serializeItemNode_OTBM(const IOMap& maphandle, NodeFileWriteHand
 
 bool IOMapOTBM::getVersionInfo(const FileName& filename, MapVersion& out_ver)
 {
-#ifdef OTGZ_SUPPORT
+#if OTGZ_SUPPORT > 0
 	if(filename.GetExt() == "otgz") {
 		// Open the archive
 		std::shared_ptr<struct archive> a(archive_read_new(), archive_read_free);
@@ -482,7 +482,7 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f,  MapVersion& out_ver)
 
 bool IOMapOTBM::loadMap(Map& map, const FileName& filename)
 {
-#ifdef OTGZ_SUPPORT
+#if OTGZ_SUPPORT > 0
 	if(filename.GetExt() == "otgz") {
 		// Open the archive
 		std::shared_ptr<struct archive> a(archive_read_new(), archive_read_free);
@@ -1144,7 +1144,7 @@ bool IOMapOTBM::loadHouses(Map& map, pugi::xml_document& doc)
 
 bool IOMapOTBM::saveMap(Map& map, const FileName& identifier)
 {
-#ifdef OTGZ_SUPPORT
+#if OTGZ_SUPPORT > 0
 	if(identifier.GetExt() == "otgz") {
 		// Create the archive
 		struct archive* a = archive_write_new();

--- a/source/item_attributes.h
+++ b/source/item_attributes.h
@@ -23,8 +23,6 @@
 
 #include "filehandle.h"
 
-#include <boost/static_assert.hpp>
-
 class IOMap;
 class ItemAttribute;
 

--- a/source/live_client.h
+++ b/source/live_client.h
@@ -34,10 +34,10 @@ class LiveClient : public LiveSocket
 
 		//
 		bool connect(const std::string& address, uint16_t port);
-		void tryConnect(boost::asio::ip::tcp::resolver::iterator endpoint);
+		void tryConnect(asio::ip::tcp::resolver::iterator endpoint);
 
 		void close();
-		bool handleError(const boost::system::error_code& error);
+		bool handleError(const std::error_code& error);
 
 		//
 		std::string getHostName() const;
@@ -83,8 +83,8 @@ class LiveClient : public LiveSocket
 		std::set<uint32_t> queryNodeList;
 		wxString currentOperation;
 
-		std::shared_ptr<boost::asio::ip::tcp::resolver> resolver;
-		std::shared_ptr<boost::asio::ip::tcp::socket> socket;
+		std::shared_ptr<asio::ip::tcp::resolver> resolver;
+		std::shared_ptr<asio::ip::tcp::socket> socket;
 
 		Editor* editor;
 

--- a/source/live_peer.cpp
+++ b/source/live_peer.cpp
@@ -24,7 +24,7 @@
 
 #include "editor.h"
 
-LivePeer::LivePeer(LiveServer* server, boost::asio::ip::tcp::socket socket) : LiveSocket(),
+LivePeer::LivePeer(LiveServer* server, asio::ip::tcp::socket socket) : LiveSocket(),
 	readMessage(), server(server), socket(std::move(socket)), color(), id(0), clientId(0), connected(false)
 {
 	ASSERT(server != nullptr);
@@ -42,13 +42,13 @@ void LivePeer::close()
 	server->removeClient(id);
 }
 
-bool LivePeer::handleError(const boost::system::error_code& error)
+bool LivePeer::handleError(const std::error_code& error)
 {
-	if(error == boost::asio::error::eof || error == boost::asio::error::connection_reset) {
+	if(error == asio::error::eof || error == asio::error::connection_reset) {
 		logMessage(wxString() + getHostName() + ": disconnected.");
 		close();
 		return true;
-	} else if(error == boost::asio::error::connection_aborted) {
+	} else if(error == asio::error::connection_aborted) {
 		logMessage(name + " have left the server.");
 		return true;
 	}
@@ -63,9 +63,9 @@ std::string LivePeer::getHostName() const
 void LivePeer::receiveHeader()
 {
 	readMessage.position = 0;
-	boost::asio::async_read(socket,
-		boost::asio::buffer(readMessage.buffer, 4),
-		[this](const boost::system::error_code& error, size_t bytesReceived) -> void {
+	asio::async_read(socket,
+		asio::buffer(readMessage.buffer, 4),
+		[this](const std::error_code& error, size_t bytesReceived) -> void {
 			if(error) {
 				if(!handleError(error)) {
 					logMessage(wxString() + getHostName() + ": " + error.message());
@@ -82,9 +82,9 @@ void LivePeer::receiveHeader()
 void LivePeer::receive(uint32_t packetSize)
 {
 	readMessage.buffer.resize(readMessage.position + packetSize);
-	boost::asio::async_read(socket,
-		boost::asio::buffer(&readMessage.buffer[readMessage.position], packetSize),
-		[this](const boost::system::error_code& error, size_t bytesReceived) -> void {
+	asio::async_read(socket,
+		asio::buffer(&readMessage.buffer[readMessage.position], packetSize),
+		[this](const std::error_code& error, size_t bytesReceived) -> void {
 			if(error) {
 				if(!handleError(error)) {
 					logMessage(wxString() + getHostName() + ": " + error.message());
@@ -108,9 +108,9 @@ void LivePeer::receive(uint32_t packetSize)
 void LivePeer::send(NetworkMessage& message)
 {
 	memcpy(&message.buffer[0], &message.size, 4);
-	boost::asio::async_write(socket,
-		boost::asio::buffer(message.buffer, message.size + 4),
-		[this](const boost::system::error_code& error, size_t bytesTransferred) -> void {
+	asio::async_write(socket,
+		asio::buffer(message.buffer, message.size + 4),
+		[this](const std::error_code& error, size_t bytesTransferred) -> void {
 			if(error) {
 				logMessage(wxString() + getHostName() + ": " + error.message());
 			}

--- a/source/live_peer.h
+++ b/source/live_peer.h
@@ -25,11 +25,11 @@ class LiveServer;
 class LivePeer : public LiveSocket
 {
 	public:
-		LivePeer(LiveServer* server, boost::asio::ip::tcp::socket socket);
+		LivePeer(LiveServer* server, asio::ip::tcp::socket socket);
 		~LivePeer();
 
 		void close();
-		bool handleError(const boost::system::error_code& error);
+		bool handleError(const std::error_code& error);
 
 		//
 		uint32_t getId() const { return id; }
@@ -69,7 +69,7 @@ class LivePeer : public LiveSocket
 		NetworkMessage readMessage;
 
 		LiveServer* server;
-		boost::asio::ip::tcp::socket socket;
+		asio::ip::tcp::socket socket;
 
 		wxColor color;
 

--- a/source/live_server.cpp
+++ b/source/live_server.cpp
@@ -45,13 +45,13 @@ bool LiveServer::bind()
 	}
 
 	auto& service = connection.get_service();
-	acceptor = std::make_shared<boost::asio::ip::tcp::acceptor>(service);
+	acceptor = std::make_shared<asio::ip::tcp::acceptor>(service);
 
-	boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), port);
+	asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port);
 	acceptor->open(endpoint.protocol());
 
-	boost::system::error_code error;
-	acceptor->set_option(boost::asio::ip::tcp::no_delay(true), error);
+	std::error_code error;
+	acceptor->set_option(asio::ip::tcp::no_delay(true), error);
 	if(error) {
 		setLastError("Error: " + error.message());
 		return false;
@@ -95,12 +95,12 @@ void LiveServer::acceptClient()
 	}
 
 	if(!socket) {
-		socket = std::make_shared<boost::asio::ip::tcp::socket>(
+		socket = std::make_shared<asio::ip::tcp::socket>(
 			NetworkConnection::getInstance().get_service()
 		);
 	}
 
-	acceptor->async_accept(*socket, [this](const boost::system::error_code& error) -> void
+	acceptor->async_accept(*socket, [this](const std::error_code& error) -> void
 	{
 		if(error) {
 			//

--- a/source/live_server.h
+++ b/source/live_server.h
@@ -73,8 +73,8 @@ class LiveServer : public LiveSocket
 	protected:
 		std::unordered_map<uint32_t, LivePeer*> clients;
 
-		std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor;
-		std::shared_ptr<boost::asio::ip::tcp::socket> socket;
+		std::shared_ptr<asio::ip::tcp::acceptor> acceptor;
+		std::shared_ptr<asio::ip::tcp::socket> socket;
 
 		Editor* editor;
 

--- a/source/main.h
+++ b/source/main.h
@@ -30,9 +30,6 @@
 
 #define _CRTDBG_MAP_ALLOC
 
-#include <stdlib.h>
-#include <crtdbg.h>
-
 #pragma warning(disable: 4291)
 _Ret_bytecap_(_Size) inline void * __CRTDECL operator new(size_t _Size, const char* file, int line)
         { return ::operator new(_Size, _NORMAL_BLOCK, file, line); }
@@ -46,14 +43,11 @@ _Ret_bytecap_(_Size) inline void* __CRTDECL operator new[](size_t _Size, const c
 
 #endif
 
-// Boost libraries
-#include <boost/utility.hpp>
-#include <boost/range/adaptor/reversed.hpp>
-#include <boost/asio.hpp>
-
 #include <wx/defs.h>
 #include "definitions.h"
 
+#include <asio.hpp>
+#include <fmt/core.h>
 #include <nlohmann/json.hpp>
 
 #include <wx/wxprec.h>
@@ -89,7 +83,7 @@ _Ret_bytecap_(_Size) inline void* __CRTDECL operator new[](size_t _Size, const c
 #include "ext/pugixml.hpp"
 
 // Libarchive, for OTGZ
-#ifdef OTGZ_SUPPORT
+#if OTGZ_SUPPORT > 0
 #include <archive.h>
 #include <archive_entry.h>
 #endif
@@ -121,8 +115,15 @@ _Ret_bytecap_(_Size) inline void* __CRTDECL operator new[](size_t _Size, const c
 #include <set>
 #include <queue>
 #include <stdexcept>
+#include <stdlib.h>
+#include <crtdbg.h>
 #include <time.h>
 #include <fstream>
+#include <memory>
+#include <exception>
+#include <cmath>
+#include <ranges>
+#include <regex>
 
 typedef std::vector<std::string> StringVector;
 typedef wxFileName FileName;

--- a/source/net_connection.cpp
+++ b/source/net_connection.cpp
@@ -101,11 +101,11 @@ bool NetworkConnection::start()
 
 	stopped = false;
 	if(!service) {
-		service = new boost::asio::io_service;
+		service = new asio::io_service;
 	}
 
 	thread = std::thread([this]() -> void {
-		boost::asio::io_service& serviceRef = *service;
+		asio::io_service& serviceRef = *service;
 		try {
 			while(!stopped) {
 				serviceRef.run_one();
@@ -132,7 +132,7 @@ void NetworkConnection::stop()
 	service = nullptr;
 }
 
-boost::asio::io_service& NetworkConnection::get_service()
+asio::io_service& NetworkConnection::get_service()
 {
 	return *service;
 }

--- a/source/net_connection.h
+++ b/source/net_connection.h
@@ -73,10 +73,10 @@ class NetworkConnection
 		bool start();
 		void stop();
 
-		boost::asio::io_service& get_service();
+		asio::io_service& get_service();
 
 	private:
-		boost::asio::io_service* service;
+		asio::io_service* service;
 		std::thread thread;
 		bool stopped;
 };

--- a/source/otml.h
+++ b/source/otml.h
@@ -18,37 +18,16 @@
 #ifndef OTML_H
 #define OTML_H
 
-#include <sstream>
-#include <fstream>
-#include <string>
-#include <vector>
-#include <exception>
-#include <memory>
-#include <algorithm>
-#include <cmath>
-#include <boost/algorithm/string.hpp>
-#include <boost/tokenizer.hpp>
-
 class OTMLNode;
 class OTMLDocument;
 class OTMLParser;
 class OTMLEmitter;
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
-typedef std::shared_ptr<OTMLNode> OTMLNodePtr;
-typedef std::enable_shared_from_this<OTMLNode> OTMLNodeEnableSharedFromThis;
-typedef std::shared_ptr<OTMLDocument> OTMLDocumentPtr;
-typedef std::weak_ptr<OTMLNode> OTMLNodeWeakPtr;
-#else
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
-typedef boost::shared_ptr<OTMLNode> OTMLNodePtr;
-typedef boost::enable_shared_from_this<OTMLNode> OTMLNodeEnableSharedFromThis;
-typedef boost::shared_ptr<OTMLDocument> OTMLDocumentPtr;
-typedef boost::weak_ptr<OTMLNode> OTMLNodeWeakPtr;
-#endif
-
-typedef std::vector<OTMLNodePtr> OTMLNodeList;
+using OTMLNodePtr = std::shared_ptr<OTMLNode>;
+using OTMLNodeEnableSharedFromThis = std::enable_shared_from_this<OTMLNode>;
+using OTMLDocumentPtr = std::shared_ptr<OTMLDocument>;
+using OTMLNodeWeakPtr = std::weak_ptr<OTMLNode>;
+using OTMLNodeList = std::vector<OTMLNodePtr>;
 
 namespace otml_util {
 	template<typename T, typename R>
@@ -147,7 +126,6 @@ namespace otml_util {
 		return r;
 	}
 };
-
 
 class OTMLException : public std::exception {
 public:
@@ -482,13 +460,13 @@ inline std::string OTMLNode::emit() {
 template<>
 inline std::string OTMLNode::value() {
 	std::string value = m_value;
-	if(boost::starts_with(value, "\"") && boost::ends_with(value, "\"")) {
+	if (value.starts_with("\"") && value.ends_with("\"")) {
 		value = value.substr(1, value.length() - 2);
-		boost::replace_all(value, "\\\\", "\\");
-		boost::replace_all(value, "\\\"", "\"");
-		boost::replace_all(value, "\\t", "\t");
-		boost::replace_all(value, "\\n", "\n");
-		boost::replace_all(value, "\\'", "\'");
+		value = std::regex_replace(value, std::regex("\\\\"), "\\");
+		value = std::regex_replace(value, std::regex("\\\""), "\"");
+		value = std::regex_replace(value, std::regex("\\t"), "\t");
+		value = std::regex_replace(value, std::regex("\\n"), "\n");
+		value = std::regex_replace(value, std::regex("\\'"), "\'");
 	}
 	return value;
 }
@@ -665,22 +643,24 @@ inline int OTMLParser::getLineDepth(const std::string& line, bool multilining) {
 
 inline void OTMLParser::parseLine(std::string line) {
 	int depth = getLineDepth(line);
-	if(depth == -1)
+	if (depth == -1)
 		return;
-	boost::trim(line);
-	if(line.empty())
+
+	trim(line);
+	if (line.empty())
 		return;
-	if(line.substr(0, 2) == "//")
+	if (line.substr(0, 2) == "//")
 		return;
-	if(depth == currentDepth + 1) {
+	if (depth == currentDepth + 1) {
 		currentParent = previousNode;
 	}
-	else if(depth < currentDepth) {
-		for(int i = 0; i<currentDepth - depth; ++i)
+	else if (depth < currentDepth) {
+		for (int i = 0; i < currentDepth - depth; ++i)
 			currentParent = currentParent->parent();
 	}
-	else if(depth != currentDepth)
+	else if (depth != currentDepth) {
 		throw OTMLException(doc, "invalid indentation depth, are you indenting correctly?", currentLine);
+	}
 	currentDepth = depth;
 	parseNode(line);
 }
@@ -692,7 +672,7 @@ inline void OTMLParser::parseNode(const std::string& data) {
 	int nodeLine = currentLine;
 	if(!data.empty() && data[0] == '-') {
 		value = data.substr(1);
-		boost::trim(value);
+		trim(value);
 	}
 	else if(dotsPos != std::string::npos) {
 		tag = data.substr(0, dotsPos);
@@ -702,8 +682,8 @@ inline void OTMLParser::parseNode(const std::string& data) {
 	else {
 		tag = data;
 	}
-	boost::trim(tag);
-	boost::trim(value);
+	trim(tag);
+	trim(value);
 	if(value == "|" || value == "|-" || value == "|+") {
 		std::string multiLineData;
 		do {
@@ -714,7 +694,7 @@ inline void OTMLParser::parseNode(const std::string& data) {
 				multiLineData += line.substr((currentDepth + 1) * 2);
 			}
 			else {
-				boost::trim(line);
+				trim(line);
 				if(!line.empty()) {
 					in.seekg(lastPos, std::ios::beg);
 					currentLine--;
@@ -740,13 +720,15 @@ inline void OTMLParser::parseNode(const std::string& data) {
 	if(value == "~")
 		node->setNull(true);
 	else {
-		if(boost::starts_with(value, "[") && boost::ends_with(value, "]")) {
-			typedef boost::tokenizer<boost::escaped_list_separator<char> > Tokenizer;
+		if (value.starts_with("[") && value.ends_with("]")) {
 			std::string tmp = value.substr(1, value.length() - 2);
-			Tokenizer tok(tmp);
-			for(Tokenizer::iterator it = tok.begin(), end = tok.end(); it != end; ++it) {
+			std::regex sep(",");
+			std::sregex_token_iterator it(tmp.begin(), tmp.end(), sep, -1);
+			std::sregex_token_iterator end;
+			std::vector<std::string> tokens(it, end);
+			for (const auto& token : tokens) {
 				std::string v = *it;
-				boost::trim(v);
+				trim(v);
 				node->writeIn(v);
 			}
 		}

--- a/source/updater.cpp
+++ b/source/updater.cpp
@@ -21,8 +21,6 @@
 
 #include <wx/url.h>
 
-#include "json.h"
-
 #include "updater.h"
 
 const wxEventType EVT_UPDATE_CHECK_FINISHED = wxNewEventType();

--- a/vcproj/Project/RME.vcxproj
+++ b/vcproj/Project/RME.vcxproj
@@ -165,7 +165,7 @@
       <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;WS2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -198,7 +198,7 @@
       <AdditionalOptions>-Zm114 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;WS2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Removed boosts (replaced with equivalent on std 14/17/20)

With this modification, there are only 16 libs for the project to add, simplifying a lot.

So two additional libraries will be needed to compile: asio and fmt

NOTE: I also fixed compiling by cmake, which was currently broken

I also removed OTGZ support by default and disabled it, making it optional (needs to be enabled). Anyone who wants to use it will need to activate this, I think it's ideal since few should use it, so a majority don't use it, which is fairer that those who need to activate it to use it than those who don't need to have this in their program. This also significantly decreases the amount of libs you need to install, as libarchive is used in OTGZ and installs several other dependencies.