### PR TITLE
fix: exception handling for reading and creating JSON objects

### DIFF
--- a/source/client_version.cpp
+++ b/source/client_version.cpp
@@ -120,9 +120,9 @@ void ClientVersion::loadVersions()
 	}
 
 	// Load the data directory info
+	using json = nlohmann::json;
 	try
 	{
-		using json = nlohmann::json;
 		json read_obj = json::parse(g_settings.getString(Config::ASSETS_DATA_DIRS));
 		auto vers_obj = read_obj.get<std::vector<json>>();
 		for (const auto& ver_iter : vers_obj) {
@@ -134,10 +134,9 @@ void ClientVersion::loadVersions()
 			version->setClientPath(wxstr(ver_obj.at("path").get<std::string>()));
 		}
 	}
-	catch (std::runtime_error&)
+	catch ([[maybe_unused]]const json::exception& e)
 	{
 		// pass
-		;
 	}
 }
 
@@ -345,17 +344,23 @@ void ClientVersion::loadVersionExtensions(pugi::xml_node versionNode)
 void ClientVersion::saveVersions()
 {
 	using json = nlohmann::json;
-	json vers_obj;
+	try {
+		json vers_obj;
 
-	for(auto& [id, version] : client_versions) {
-		json ver_obj;
-		ver_obj["id"] = version->getName();
-		ver_obj["path"] = version->getClientPath().GetFullPath().ToStdString();
-		vers_obj.push_back(ver_obj);
+		for(auto& [id, version] : client_versions) {
+			json ver_obj;
+			ver_obj["id"] = version->getName();
+			ver_obj["path"] = version->getClientPath().GetFullPath().ToStdString();
+			vers_obj.push_back(ver_obj);
+		}
+
+		std::ostringstream out;
+		out << vers_obj;
+		g_settings.setString(Config::ASSETS_DATA_DIRS, out.str());
 	}
-	std::ostringstream out;
-	out << vers_obj;
-	g_settings.setString(Config::ASSETS_DATA_DIRS, out.str());
+	catch ([[maybe_unused]]const json::exception& e) {
+		// pass
+	}
 }
 
 // Client version class

--- a/vcproj/Project/RME.vcxproj
+++ b/vcproj/Project/RME.vcxproj
@@ -109,6 +109,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Rpcrt4.lib;WS2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -136,6 +137,7 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Rpcrt4.lib;WS2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
This adds exception handling to the code that reads and creates JSON objects in the program. The code now uses try-catch blocks to catch exceptions that may be thrown during the process of reading and writing JSON objects, to avoid unhandled failures that may interrupt the program's execution. With these changes, the program can now handle errors in a more robust way and offer a better user experience. When the user opened the file for the first time, it crashed to create the windows register (as soon as it happened or crashed, the register didn't exist yet).

I also added the fix to the debug compilation, which was not linking to c++ 20.