### PR TITLE
Go to house with no exit

### DIFF
--- a/source/house.h
+++ b/source/house.h
@@ -50,6 +50,8 @@ public:
 	uint8_t getEmptyDoorID() const;
 	Position getDoorPositionByID(uint8_t id) const;
 
+	const PositionList& getTiles() const { return tiles; }
+
 protected:
 	Map* map;
 	PositionList tiles;

--- a/source/palette_house.cpp
+++ b/source/palette_house.cpp
@@ -333,10 +333,19 @@ void HousePalettePanel::OnListBoxChange(wxCommandEvent& event)
 
 void HousePalettePanel::OnListBoxDoubleClick(wxCommandEvent& event)
 {
-	House* house = reinterpret_cast<House*>(event.GetClientData());
-	// I find it extremly unlikely that one actually wants the exit at 0,0,0, so just treat it as the null value
-	if(house && house->getExit() != Position(0,0,0)) {
-		g_gui.SetScreenCenterPosition(house->getExit());
+	if (House* house = reinterpret_cast<House*>(event.GetClientData())) {
+		const Position& position = house->getExit();
+		if (!position.isValid()) {
+			// find a valid tile position
+			for (const Position& tilePosition : house->getTiles()) {
+				if (tilePosition.isValid()) {
+					g_gui.SetScreenCenterPosition(tilePosition);
+					break;
+				}
+			}
+		} else {
+			g_gui.SetScreenCenterPosition(position);
+		}
 	}
 }
 


### PR DESCRIPTION
Now when you double click a house with no exit, it will take you to the first valid tile.

Makes easier to fix the warning about houses with no exit.